### PR TITLE
Add game state serialization, verification, and pause menu save controls

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -85,6 +85,8 @@ TutorialProperties="*res://src/singletons/properties/tutorial_properties.gd"
 ButtonSounds="*res://src/singletons/button_sounds.gd"
 SfxPaths="*res://src/singletons/sfx_paths.gd"
 Secrets="*res://src/singletons/secrets.gd"
+GameStateSerializer="*res://src/singletons/game_state_serializer.gd"
+GameStateVerifier="*res://src/singletons/game_state_verifier.gd"
 Nakama="*res://addons/com.heroiclabs.nakama/Nakama.gd"
 NakamaConnection="*res://src/singletons/nakama_connection.gd"
 OnlineMatch="*res://addons/nakama-webrtc/OnlineMatch.gd"
@@ -113,6 +115,10 @@ window/size/viewport_height=1440
 window/size/mode=3
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
+
+[network]
+
+checksum/use_game_state_hash_tree=false
 
 [gui]
 

--- a/src/game_scene/game_client.gd
+++ b/src/game_scene/game_client.gd
@@ -236,6 +236,14 @@ func _do_tick():
 
 
 func _calculate_game_state_checksum():
+	var use_tree: bool = ProjectSettings.get_setting("network/checksum/use_game_state_hash_tree", false)
+	if use_tree:
+		var scene: Node = get_tree().current_scene
+		if scene != null:
+			var digest: PackedByteArray = GameStateVerifier.compute_scene_digest(scene)
+			if !digest.is_empty():
+				return digest
+
 	var ctx: HashingContext = HashingContext.new()
 	ctx.start(HashingContext.HASH_MD5)
 

--- a/src/game_scene/game_scene.gd
+++ b/src/game_scene/game_scene.gd
@@ -168,6 +168,8 @@ func _ready():
 	if Config.run_test_item_drop_chances():
 		TestItemDropChances.run()
 
+	GameStateVerifier.verify_scene(self)
+
 
 func _unhandled_input(event: InputEvent):
 	var enter_pressed: bool = event.is_action_released("ui_text_newline")
@@ -574,6 +576,18 @@ func _cleanup_all_objects():
 #########################
 ###     Callbacks     ###
 #########################
+
+func _on_game_menu_save_requested(path: String):
+	var err: int = GameStateSerializer.save_game_scene(self, path)
+	if err != OK:
+		push_error("Failed to save game: %s" % err)
+	else:
+		print_verbose("Saved game to %s" % path)
+
+func _on_game_menu_load_requested(path: String):
+	var err: int = GameStateSerializer.load_game_scene(path)
+	if err != OK:
+		push_error("Failed to load game: %s" % err)
 
 func _on_game_menu_continue_pressed():
 	_toggle_game_menu()

--- a/src/game_scene/game_scene.tscn
+++ b/src/game_scene/game_scene.tscn
@@ -508,6 +508,8 @@ layout_mode = 2
 [connection signal="received_first_timeslot" from="Gameplay/GameClient" to="." method="_on_game_client_received_first_timeslot"]
 [connection signal="tutorial_triggered" from="Gameplay/TutorialController" to="." method="_on_tutorial_controller_tutorial_triggered"]
 [connection signal="finished" from="UI/BuilderMenu" to="." method="_on_builder_menu_finished"]
+[connection signal="save_requested" from="UI/GameMenu" to="." method="_on_game_menu_save_requested"]
+[connection signal="load_requested" from="UI/GameMenu" to="." method="_on_game_menu_load_requested"]
 [connection signal="continue_pressed" from="UI/GameMenu" to="." method="_on_game_menu_continue_pressed"]
 [connection signal="quit_pressed" from="UI/GameMenu" to="." method="_on_game_menu_quit_pressed"]
 [connection signal="hidden" from="UI/VBoxContainer/TutorialMenu" to="." method="_on_tutorial_menu_hidden"]

--- a/src/game_state/game_state_save.gd
+++ b/src/game_state/game_state_save.gd
@@ -1,0 +1,8 @@
+extends Resource
+class_name GameStateSave
+
+
+@export var format_version: int = 1
+@export var scene: PackedScene
+@export var hash_tree: Dictionary = {}
+@export var metadata: Dictionary = {}

--- a/src/singletons/game_state_serializer.gd
+++ b/src/singletons/game_state_serializer.gd
@@ -1,0 +1,94 @@
+extends Node
+class_name GameStateSerializer
+
+
+const CURRENT_FORMAT_VERSION: int = 1
+const DEFAULT_SAVE_DIR: String = "user://saves"
+const DEFAULT_EXTENSION: String = ".ytdsave"
+
+
+var _last_save_error: int = OK
+
+
+func get_default_save_dir() -> String:
+	return DEFAULT_SAVE_DIR
+
+
+func get_default_extension() -> String:
+	return DEFAULT_EXTENSION
+
+
+func get_last_save_error() -> int:
+	return _last_save_error
+
+
+func ensure_default_save_dir():
+	DirAccess.make_dir_recursive_absolute(DEFAULT_SAVE_DIR)
+
+
+func save_game_scene(game_scene: Node, path: String, metadata: Dictionary = {}) -> int:
+	if game_scene == null:
+		_last_save_error = ERR_INVALID_PARAMETER
+		return _last_save_error
+
+	var normalized_path: String = _normalize_path(path)
+	var dir_path: String = normalized_path.get_base_dir()
+	if !dir_path.is_empty():
+		DirAccess.make_dir_recursive_absolute(dir_path)
+
+	var packed_scene := PackedScene.new()
+	var pack_err: int = packed_scene.pack(game_scene)
+	if pack_err != OK:
+		_last_save_error = pack_err
+		return _last_save_error
+
+	var hash_tree: Dictionary = GameStateVerifier.build_hashed_tree_from_scene(game_scene)
+	var save_resource := GameStateSave.new()
+	save_resource.format_version = CURRENT_FORMAT_VERSION
+	save_resource.scene = packed_scene
+	save_resource.hash_tree = hash_tree
+	save_resource.metadata = metadata
+
+	var save_err: int = ResourceSaver.save(save_resource, normalized_path)
+	_last_save_error = save_err
+
+	return save_err
+
+
+func load_game_scene(path: String) -> int:
+	var normalized_path: String = _normalize_path(path)
+	if !FileAccess.file_exists(normalized_path):
+		return ERR_FILE_NOT_FOUND
+
+	var save_resource: GameStateSave = ResourceLoader.load(normalized_path, "GameStateSave") as GameStateSave
+	if save_resource == null:
+		return ERR_FILE_CORRUPT
+
+	if save_resource.format_version != CURRENT_FORMAT_VERSION:
+		return ERR_INVALID_DATA
+
+	if save_resource.scene == null:
+		return ERR_INVALID_DATA
+
+	GameStateVerifier.schedule_expected_hash_tree(save_resource.hash_tree, normalized_path)
+
+	var tree: SceneTree = get_tree()
+	tree.paused = false
+	var change_err: int = tree.change_scene_to_packed(save_resource.scene)
+	return change_err
+
+
+func _normalize_path(path: String) -> String:
+	var trimmed_path: String = path.strip_edges()
+	if trimmed_path.is_empty():
+		return DEFAULT_SAVE_DIR.path_join("autosave" + DEFAULT_EXTENSION)
+
+	var extension_without_dot: String = DEFAULT_EXTENSION.trim_prefix(".")
+	var current_extension: String = trimmed_path.get_extension()
+	if current_extension.is_empty():
+		return trimmed_path + DEFAULT_EXTENSION
+
+	if current_extension != extension_without_dot:
+		return trimmed_path.get_basename() + DEFAULT_EXTENSION
+
+	return trimmed_path

--- a/src/singletons/game_state_verifier.gd
+++ b/src/singletons/game_state_verifier.gd
@@ -1,0 +1,211 @@
+extends Node
+class_name GameStateVerifier
+
+
+static var _expected_hash_tree: Dictionary = {}
+static var _expected_source: String = ""
+
+
+static func build_hashed_tree_from_scene(scene: Node) -> Dictionary:
+	if scene == null:
+		return {}
+
+	var packed_scene := PackedScene.new()
+	var pack_err: int = packed_scene.pack(scene)
+	if pack_err != OK:
+		push_error("Failed to pack scene for hashing: %s" % pack_err)
+		return {}
+
+	return _build_hashed_tree_from_state(packed_scene.get_state())
+
+
+static func compute_scene_digest(scene: Node) -> PackedByteArray:
+	var hashed_tree: Dictionary = build_hashed_tree_from_scene(scene)
+	if hashed_tree.is_empty():
+		return PackedByteArray()
+
+	var root_hash: String = hashed_tree.get("hash", "")
+	if root_hash.is_empty():
+		return PackedByteArray()
+
+	return Marshalls.base64_to_raw(root_hash)
+
+
+static func schedule_expected_hash_tree(hash_tree: Dictionary, source: String):
+	GameStateVerifier._expected_hash_tree = hash_tree
+	GameStateVerifier._expected_source = source
+
+
+static func has_pending_verification() -> bool:
+	return !GameStateVerifier._expected_hash_tree.is_empty()
+
+
+static func verify_scene(scene: Node):
+	if !has_pending_verification():
+		return
+
+	var hashed_tree: Dictionary = build_hashed_tree_from_scene(scene)
+	var differences: Array = _compare_hash_trees(_expected_hash_tree, hashed_tree, [])
+	if differences.is_empty():
+		print_verbose("Game state verified successfully for %s" % _expected_source)
+	else:
+		for diff in differences:
+			var path: Array = diff.get("path", [])
+			var expected: Variant = diff.get("expected")
+			var actual: Variant = diff.get("actual")
+			push_error("Game state mismatch at %s expected %s actual %s" % ["/".join(path), expected, actual])
+
+	_expected_hash_tree = {}
+	_expected_source = ""
+
+
+static func _build_hashed_tree_from_state(state: SceneState) -> Dictionary:
+	var node_count: int = state.get_node_count()
+	var info_list: Array = []
+
+	for node_index in range(node_count):
+		var node_dict: Dictionary = {}
+		node_dict["name"] = state.get_node_name(node_index)
+		node_dict["type"] = state.get_node_type(node_index)
+		var properties: Dictionary = {}
+
+		var property_count: int = state.get_node_property_count(node_index)
+		for property_index in range(property_count):
+			var property_name: String = state.get_node_property_name(node_index, property_index)
+			var property_value: Variant = state.get_node_property_value(node_index, property_index)
+			properties[property_name] = property_value
+
+		node_dict["properties"] = properties
+		node_dict["children"] = []
+
+		var node_path: NodePath = state.get_node_path(node_index)
+		var names: Array = _path_to_names(node_path, node_dict["name"])
+		info_list.append({
+			"names": names,
+			"data": node_dict,
+		})
+
+	info_list.sort_custom(
+		func(a, b) -> bool:
+			return a["names"].size() < b["names"].size()
+	)
+
+	var key_to_node: Dictionary = {}
+	var root: Dictionary = {}
+
+	for info in info_list:
+		var names: Array = info["names"]
+		var key: String = _join_names(names)
+		var data: Dictionary = info["data"]
+		key_to_node[key] = data
+
+		if names.size() <= 1:
+			root = data
+			continue
+
+		var parent_names: Array = names.duplicate()
+		parent_names.resize(names.size() - 1)
+		var parent_key: String = _join_names(parent_names)
+		if key_to_node.has(parent_key):
+			var parent_node: Dictionary = key_to_node[parent_key]
+			var children: Array = parent_node.get("children", [])
+			children.append(data)
+			parent_node["children"] = children
+
+	return _attach_hashes(root)
+
+
+static func _attach_hashes(node: Dictionary) -> Dictionary:
+	var children: Array = node.get("children", [])
+	var hashed_children: Array = []
+	for child in children:
+		hashed_children.append(_attach_hashes(child))
+
+	var properties: Dictionary = node.get("properties", {})
+	var sorted_keys: Array = properties.keys()
+	sorted_keys.sort()
+	var buffer := PackedByteArray()
+	buffer.append_array(var_to_bytes(node.get("name", "")))
+	buffer.append_array(var_to_bytes(node.get("type", "")))
+	for key in sorted_keys:
+		buffer.append_array(var_to_bytes(key))
+		buffer.append_array(var_to_bytes_with_objects(properties[key]))
+	for child_dict in hashed_children:
+		buffer.append_array(Marshalls.base64_to_raw(child_dict.get("hash", "")))
+
+	var digest: PackedByteArray = Crypto.digest(Crypto.HashType.SHA256, buffer)
+	var hash_string: String = Marshalls.raw_to_base64(digest)
+
+	return {
+		"name": node.get("name", ""),
+		"type": node.get("type", ""),
+		"properties": properties,
+		"children": hashed_children,
+		"hash": hash_string,
+	}
+
+
+static func _path_to_names(path: NodePath, node_name: String) -> Array:
+	var names: Array = []
+	var count: int = path.get_name_count()
+	for index in range(count):
+		names.append(path.get_name(index))
+
+	if names.is_empty():
+		names.append(node_name)
+
+	return names
+
+
+static func _join_names(names: Array) -> String:
+	return "/".join(names)
+
+
+static func _compare_hash_trees(expected: Dictionary, actual: Dictionary, path: Array) -> Array:
+	var differences: Array = []
+	var current_path: Array = path.duplicate()
+	current_path.append(expected.get("name", ""))
+
+	if expected.get("hash", "") == actual.get("hash", ""):
+		return differences
+
+	var expected_children: Array = expected.get("children", [])
+	var actual_children: Array = actual.get("children", [])
+	var actual_map: Dictionary = {}
+	for child in actual_children:
+		var key: String = _child_key(child)
+		actual_map[key] = child
+
+	for expected_child in expected_children:
+		var child_key: String = _child_key(expected_child)
+		if actual_map.has(child_key):
+			var child_diff: Array = _compare_hash_trees(expected_child, actual_map[child_key], current_path)
+			differences.append_array(child_diff)
+			actual_map.erase(child_key)
+		else:
+			differences.append({
+				"path": current_path + [expected_child.get("name", "")],
+				"expected": expected_child.get("hash", ""),
+				"actual": "MISSING",
+			})
+
+	for remaining_key in actual_map.keys():
+		var remaining_child: Dictionary = actual_map[remaining_key]
+		differences.append({
+			"path": current_path + [remaining_child.get("name", "")],
+			"expected": "MISSING",
+			"actual": remaining_child.get("hash", ""),
+		})
+
+	if differences.is_empty():
+		differences.append({
+			"path": current_path,
+			"expected": expected.get("hash", ""),
+			"actual": actual.get("hash", ""),
+		})
+
+	return differences
+
+
+static func _child_key(node: Dictionary) -> String:
+	return "%s:%s" % [node.get("name", ""), node.get("type", "")]

--- a/src/ui/game_menu/game_menu.gd
+++ b/src/ui/game_menu/game_menu.gd
@@ -11,14 +11,28 @@ enum Tab {
 
 signal continue_pressed()
 signal quit_pressed()
+signal save_requested(path: String)
+signal load_requested(path: String)
 
 
 @export var _tab_container: TabContainer
 @export var _settings_menu: SettingsMenu
+@export var _save_dialog: FileDialog
+@export var _load_dialog: FileDialog
 
 
 func _ready():
 	_settings_menu.set_opened_in_game(true)
+	GameStateSerializer.ensure_default_save_dir()
+	var save_dir: String = GameStateSerializer.get_default_save_dir()
+	var extension: String = GameStateSerializer.get_default_extension()
+	var filter: String = "*%s ; YouTD2 Save" % extension
+	_save_dialog.filters = PackedStringArray([filter])
+	_load_dialog.filters = PackedStringArray([filter])
+	_save_dialog.access = FileDialog.ACCESS_USERDATA
+	_load_dialog.access = FileDialog.ACCESS_USERDATA
+	_save_dialog.current_dir = save_dir
+	_load_dialog.current_dir = save_dir
 
 
 func switch_to_help_menu():
@@ -67,3 +81,19 @@ func _on_encyclopedia_button_pressed() -> void:
 
 func _on_encyclopedia_menu_close_pressed() -> void:
 	_tab_container.current_tab = Tab.MAIN
+
+
+func _on_save_button_pressed():
+	_save_dialog.popup_centered()
+
+
+func _on_load_button_pressed():
+	_load_dialog.popup_centered()
+
+
+func _on_save_dialog_file_selected(path: String):
+	save_requested.emit(path)
+
+
+func _on_load_dialog_file_selected(path: String):
+	load_requested.emit(path)

--- a/src/ui/game_menu/game_menu.tscn
+++ b/src/ui/game_menu/game_menu.tscn
@@ -8,11 +8,13 @@
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_6c4dp"]
 
-[node name="GameMenu" type="VBoxContainer" node_paths=PackedStringArray("_tab_container", "_settings_menu")]
+[node name="GameMenu" type="VBoxContainer" node_paths=PackedStringArray("_tab_container", "_settings_menu", "_save_dialog", "_load_dialog")]
 theme = ExtResource("1_v8b77")
 script = ExtResource("1_8lyul")
 _tab_container = NodePath("TabContainer")
 _settings_menu = NodePath("TabContainer/SettingsMenu")
+_save_dialog = NodePath("SaveDialog")
+_load_dialog = NodePath("LoadDialog")
 
 [node name="TabContainer" type="TabContainer" parent="."]
 layout_mode = 2
@@ -50,6 +52,16 @@ layout_mode = 2
 focus_mode = 0
 text = "SETTINGS_BUTTON"
 
+[node name="SaveButton" type="Button" parent="TabContainer/MainTab/VBoxContainer"]
+layout_mode = 2
+focus_mode = 0
+text = "SAVE_GAME_BUTTON"
+
+[node name="LoadButton" type="Button" parent="TabContainer/MainTab/VBoxContainer"]
+layout_mode = 2
+focus_mode = 0
+text = "LOAD_GAME_BUTTON"
+
 [node name="QuitButton" type="Button" parent="TabContainer/MainTab/VBoxContainer"]
 layout_mode = 2
 focus_mode = 0
@@ -70,13 +82,23 @@ visible = false
 layout_mode = 2
 metadata/_tab_index = 3
 
+[node name="SaveDialog" type="FileDialog" parent="."]
+file_mode = 4
+
+[node name="LoadDialog" type="FileDialog" parent="."]
+file_mode = 0
+
 [connection signal="hidden" from="." to="." method="_on_hidden"]
 [connection signal="pressed" from="TabContainer/MainTab/VBoxContainer/ContinueButton" to="." method="_on_continue_button_pressed"]
 [connection signal="pressed" from="TabContainer/MainTab/VBoxContainer/HelpButton" to="." method="_on_help_button_pressed"]
 [connection signal="pressed" from="TabContainer/MainTab/VBoxContainer/EncyclopediaButton" to="." method="_on_encyclopedia_button_pressed"]
 [connection signal="pressed" from="TabContainer/MainTab/VBoxContainer/SettingsButton" to="." method="_on_settings_button_pressed"]
+[connection signal="pressed" from="TabContainer/MainTab/VBoxContainer/SaveButton" to="." method="_on_save_button_pressed"]
+[connection signal="pressed" from="TabContainer/MainTab/VBoxContainer/LoadButton" to="." method="_on_load_button_pressed"]
 [connection signal="pressed" from="TabContainer/MainTab/VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]
 [connection signal="closed" from="TabContainer/HintsMenu" to="." method="_on_help_menu_closed"]
 [connection signal="close_pressed" from="TabContainer/EncyclopediaMenu" to="." method="_on_encyclopedia_menu_close_pressed"]
 [connection signal="cancel_pressed" from="TabContainer/SettingsMenu" to="." method="_on_settings_menu_cancel_pressed"]
 [connection signal="ok_pressed" from="TabContainer/SettingsMenu" to="." method="_on_settings_menu_ok_pressed"]
+[connection signal="file_selected" from="SaveDialog" to="." method="_on_save_dialog_file_selected"]
+[connection signal="file_selected" from="LoadDialog" to="." method="_on_load_dialog_file_selected"]


### PR DESCRIPTION
## Summary
- add game state serializer/verifier singletons that snapshot the scene tree, build hash metadata, and load saves
- expose save/load controls on the game menu with file dialogs wired to the serializer and new callbacks in `GameScene`
- allow multiplayer checksums to optionally use the hashed game state and register supporting resources/project settings

## Testing
- not run (Godot headless runtime unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5bda1d010832b8af8414b942d32f7